### PR TITLE
Enhance File Transfer Reliability with CRC, Timeout, and Progress Logging

### DIFF
--- a/include/file_transfer.h
+++ b/include/file_transfer.h
@@ -25,6 +25,58 @@
 extern "C" {
 #endif
 
+
+/*
+ * Constants for file transfer and client-server communication.
+ *
+ * MAX_CHUNKS         - Maximum number of chunks a file can be divided into.
+ * MAX_CHUNK_SIZE     - Maximum size (in bytes) of each file chunk.
+ * MAX_CLIENTS        - Maximum number of clients that can connect simultaneously.
+ * MAX_MESSAGE_SIZE   - Maximum size (in bytes) of a message exchanged between client and server.
+ */
+#define MAX_CHUNKS 64
+#define MAX_CHUNK_SIZE 256
+#define MAX_CLIENTS 64
+#define MAX_MESSAGE_SIZE 4096
+/**
+ * @struct FileBuffer
+ * @brief Represents the state and data of a file being transferred.
+ *
+ * This structure is used to manage the reception of a file in chunks,
+ * keeping track of which chunks have been received, the source of the file,
+ * and associated metadata.
+ *
+ * @var FileBuffer::active
+ * Indicates whether the file buffer is currently in use (1 for active, 0 for inactive).
+ *
+ * @var FileBuffer::src_id
+ * Identifier for the source (e.g., client or server) sending the file.
+ *
+ * @var FileBuffer::filename
+ * Name of the file being transferred (null-terminated string, max 255 characters).
+ *
+ * @var FileBuffer::chunks
+ * 2D array storing the received file chunks. Each chunk can hold up to MAX_CHUNK_SIZE bytes plus a null terminator.
+ *
+ * @var FileBuffer::received
+ * Array indicating which chunks have been received (1 for received, 0 for not received).
+ *
+ * @var FileBuffer::final_seq
+ * Sequence number of the last chunk in the file transfer.
+ *
+ * @var FileBuffer::last_received
+ * Timestamp of the last received chunk (time_t).
+ */
+typedef struct {
+    int active;
+    int src_id;
+    char filename[256];
+    char chunks[MAX_CHUNKS][MAX_CHUNK_SIZE + 1];
+    int received[MAX_CHUNKS];
+    int final_seq;
+    time_t last_received;
+} FileBuffer;
+
 /**
  * @brief Sends a file to the connected client in chunked protocol frames.
  *        Each chunk includes CRC, sequence number, and END flag.

--- a/src/client/client_listener.c
+++ b/src/client/client_listener.c
@@ -40,6 +40,16 @@ static void check_file_transfer_timeouts(int sockfd) {
             buf->active = 0;
         }
     }
+    for (int i = 0; i <= buf->final_seq; ++i) {
+    if (!buf->received[i]) {
+        char retry[MAX_COMMAND_LENGTH];
+        snprintf(retry, sizeof(retry), "RETRY|%d", i);
+        build_frame("file", 0, buf->src_id, retry, "RETRY", retry);
+        send(sockfd, retry, strlen(retry), 0);
+        log_message(LOG_INFO, "[FILE] Requested retry for missing chunk #%d from client %d", i, buf->src_id);
+    }
+}
+
 }
 
 /**

--- a/src/client/client_listener.c
+++ b/src/client/client_listener.c
@@ -39,16 +39,16 @@ static void check_file_transfer_timeouts(int sockfd) {
 
             buf->active = 0;
         }
+        for (int i = 0; i <= buf->final_seq; ++i) {
+            if (!buf->received[i]) {
+                char retry[MAX_COMMAND_LENGTH];
+                snprintf(retry, sizeof(retry), "RETRY|%d", i);
+                build_frame("file", 0, buf->src_id, retry, "RETRY", retry);
+                send(sockfd, retry, strlen(retry), 0);
+                log_message(LOG_INFO, "[FILE] Requested retry for missing chunk #%d from client %d", i, buf->src_id);
+            }
+        }
     }
-    for (int i = 0; i <= buf->final_seq; ++i) {
-    if (!buf->received[i]) {
-        char retry[MAX_COMMAND_LENGTH];
-        snprintf(retry, sizeof(retry), "RETRY|%d", i);
-        build_frame("file", 0, buf->src_id, retry, "RETRY", retry);
-        send(sockfd, retry, strlen(retry), 0);
-        log_message(LOG_INFO, "[FILE] Requested retry for missing chunk #%d from client %d", i, buf->src_id);
-    }
-}
 
 }
 

--- a/src/features/file_transfer.c
+++ b/src/features/file_transfer.c
@@ -55,7 +55,12 @@ void send_file_to_client(int* connfd, const char* filename, int src_id, int dest
         log_message(LOG_ERROR, "File not found: %s", path);
         return;
     }
+    // Get file size
+    fseek(fp, 0, SEEK_END);
+    long file_size = ftell(fp);
+    rewind(fp);  // Reset for reading
 
+    log_message(LOG_INFO, "[FILE] Preparing to send '%s' (%ld bytes) to client %d", filename, file_size, dest_id);
     char chunk[MAX_CHUNK_SIZE + 1];
     int seq = 0;
     size_t bytes;

--- a/src/features/file_transfer.c
+++ b/src/features/file_transfer.c
@@ -55,6 +55,7 @@ void send_file_to_client(int* connfd, const char* filename, int src_id, int dest
     fseek(fp, 0, SEEK_END);
     long file_size = ftell(fp);
     rewind(fp);  // Reset for reading
+    int total_chunks = (file_size + MAX_CHUNK_SIZE - 1) / MAX_CHUNK_SIZE;
 
     log_message(LOG_INFO, "[FILE] Preparing to send '%s' (%ld bytes) to client %d", filename, file_size, dest_id);
     char chunk[MAX_CHUNK_SIZE + 1];
@@ -76,6 +77,9 @@ void send_file_to_client(int* connfd, const char* filename, int src_id, int dest
 
         log_message(LOG_INFO, "[FILE] Sent chunk #%d to client %d", seq, dest_id);
         seq++;
+        log_message(LOG_INFO, "[FILE] Progress: Sent %d/%d chunks (%.2f%%) to client %d",
+            seq + 1, total_chunks, (100.0 * (seq + 1)) / total_chunks, dest_id);
+
     }
 
     fclose(fp);


### PR DESCRIPTION
📝 Task Title
Enhance File Transfer Reliability with CRC, Timeout, and Progress Logging

📌 Summary
This merge request introduces robust improvements to the client-server file transfer system. It adds CRC validation, timeout detection, retry scaffolding, and progress logging to ensure reliable, chunked delivery of files between clients.

These enhancements solve issues related to silent failures, stalled transfers, and lack of visibility during transmission. It’s part of the modular file transfer milestone and complements the protocol integrity layer introduced earlier.

📂 Related File Changes
file_transfer.c — Added file size logging, timestamp tracking, and chunk progress reporting

file_transfer.h — Exposed FileBuffer and buffers for timeout logic

client_listener.c — Integrated timeout detection and retry scaffolding

protocol.c / parser.c — CRC validation reused via parse_command()

Makefile — No changes required

🧪 Testing
[x] Manual testing with multiple clients

[x] Verified CRC mismatch handling

[x] Simulated stalled transfers to confirm timeout triggers

[x] Observed progress logs during large file sends

[x] Confirmed ACK/ERR behavior on reassembly

🧠 Notes for Reviewers
Timeout logic runs per chunk and aborts stalled transfers after 10 seconds

Retry logic is scaffolded but not yet wired to resend logic—can be extended

FileBuffer is now globally visible; ensure no unintended access

Progress logs are verbose—can be throttled or toggled later



✅ Checklist
[x] Code compiles without errors

[x] No hardcoded values or debug prints

[x] Doxygen comments updated

[x] No memory leaks or buffer overflows

[x] Feature works as described

🔗 Related Issues / Discussions
